### PR TITLE
Add missing fallback definition for `compile_assert_const_p`

### DIFF
--- a/compile_assert.h
+++ b/compile_assert.h
@@ -88,6 +88,7 @@
 #else
 #define compile_assert(condition, description)
 #define compile_assert0(expression)
+#define compile_assert_const_p(expression, message)
 #endif
 
 


### PR DESCRIPTION
`compile_assert`, `compile_assert0` and `compile_assert_const_p` are defined above, but only the first two have fallback definitions. Add the missing one.