### PR TITLE
Make `compile_assert` variadic and improve constant p macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 *.exe
 *.out
 *.app
+*.bin
 
 # debug information files
 *.dwo

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# debug information files
+*.dwo
+
+# Modules
+**/gcm.cache/
+
+# Mac
+*.DS_Store
+
+# IDE
+*.idea/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -96,20 +96,36 @@ compile_assert(condition, description) where description is not logged, it is an
 Sometimes, there might be some small changes needed, to make a suitable place to call compile_assert().
 
 # sample output main13 library API example
+The checked public API `log_api(str, length)` validates both arguments on the caller's side. 
+main13.c calls `log_api` with a NULL string and a zero length, so both the `compile_assert_never_null` and `compile_assert_scalar` checks fire at compile time:
+
 ```C
 $ make
-gcc -Wall -Wextra -O3 -std=c11 -c -o main13.o main13.c
+gcc -Wall -Wextra -O3 -std=c11 -D__ENABLE_COMPILE_ASSERT__ -c -o main13.o main13.c
 In file included from main13.c:8:
-main13.c: In function ‘main’:
-<snip>
-main13_api.h:14:5: note: in expansion of macro ‘compile_assert’
-   14 |     compile_assert((str != NULL), "cannot be NULL"); \
-      |     ^~~~~~~~~~~~~~
-main13.c:16:5: note: in expansion of macro ‘log_api’
-   16 |     log_api(str);
-      |     ^~~~~~~
-make: *** [makefile:17: main13.o] Error 1
+main13.c: In function 'main':
+./../compile_assert.h:159:57: error: call to '_stop_compile2' declared with attribute error: 'compile_assert pointer error detected'
+  159 | #define compile_assert_never_null(ptr) ((ptr) ? (ptr) : _stop_compile2())
+      |                                                         ^~~~~~~~~~~~~~~~
+main13_api.h:11:48: note: in expansion of macro 'compile_assert_never_null'
+   11 | #define log_api(str, length) _internal_log_api(compile_assert_never_null(str), compile_assert_scalar((length != 0), length))
+      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~
+main13.c:18:18: note: in expansion of macro 'log_api'
+   18 |     int result = log_api(str, 0);
+      |                  ^~~~~~~
+./../compile_assert.h:191:74: error: call to '_stop_compile3' declared with attribute error: 'compile_assert_scalar error detected'
+  191 | #define compile_assert_scalar(condition, scalar) ((condition) ? (scalar) : _stop_compile3())
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
+main13_api.h:11:80: note: in expansion of macro 'compile_assert_scalar'
+   11 | #define log_api(str, length) _internal_log_api(compile_assert_never_null(str), compile_assert_scalar((length != 0), length))
+      |                                                                                ^~~~~~~~~~~~~~~~~~~~~
+main13.c:18:18: note: in expansion of macro 'log_api'
+   18 |     int result = log_api(str, 0);
+      |                  ^~~~~~~
+make: *** [main13.o] Error 1
 ```
+
+Fixing the two FIXMEs in main13.c satisfies both of the checks.
 
 # compile_assert compared to UBSAN
 

--- a/compile_assert.h
+++ b/compile_assert.h
@@ -90,9 +90,47 @@
 // The optional trailing arguments name the operands that must be compile-time constants for the
 // check to fire; with none given, the condition itself is the guarded operand:
 //
+//   compile_assert_const_p(condition, message)             guard on the condition
+//   compile_assert_const_p(condition, message, a)          guard on operand a
+//   compile_assert_const_p(condition, message, a, b, ...)  guard on every listed operand (ANDed)
+//
+// GCC before 13 does not fold __builtin_constant_p when it is applied to a value derived from
+// an overflow builtin, or even to a comparison in a deep constexpr call chain, so a guard on
+// the condition is missed and the assertion never fires. Naming the raw operands (plain
+// integers, which fold on every supported GCC) makes the check fire on GCC 11 and 12 as well
+//
+// __builtin_constant_p of every listed operand, ANDed together.
+// Up to 8 arguments are currently supported
+#define CA_G1(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G2(__VA_ARGS__))
+#define CA_G2(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G3(__VA_ARGS__))
+#define CA_G3(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G4(__VA_ARGS__))
+#define CA_G4(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G5(__VA_ARGS__))
+#define CA_G5(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G6(__VA_ARGS__))
+#define CA_G6(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G7(__VA_ARGS__))
+#define CA_G7(a, ...) __builtin_constant_p(a) __VA_OPT__(&& CA_G8(__VA_ARGS__))
+#define CA_G8(a) __builtin_constant_p(a)
+#define CA_GUARD(...) CA_G1(__VA_ARGS__)
+
+// Pick the guard expression
+#define CA_CONST_P_GUARD_(condition, ...)  __builtin_constant_p(condition)
+#define CA_CONST_P_GUARD_1(condition, ...) CA_GUARD(__VA_ARGS__)
+#define CA_CONST_P_GUARD(condition, ...) \
+    CA_CAT(CA_CONST_P_GUARD_, __VA_OPT__(1))(condition, __VA_ARGS__)
+
+#define CA_CONST_P_IMPL(condition, message, guard, fn) \
+    do { \
+        if (guard) { \
+            if (!(condition)) { \
+                void fn() __attribute__ ((error(message))); \
+                fn(); \
             } \
         } \
     } while (0)
+#define compile_assert_const_p(condition, message, ...) \
+    CA_CONST_P_IMPL( \
+        condition, message, \
+        CA_CONST_P_GUARD(condition, __VA_ARGS__), \
+        CA_CAT(_compile_assert_fail_, __COUNTER__))
 
 
 #define compile_assert0(expression) compile_assert(expression, NULL)
@@ -100,7 +138,7 @@
 #else
 #define compile_assert(condition, description)
 #define compile_assert0(expression)
-#define compile_assert_const_p(expression, message)
+#define compile_assert_const_p(condition, message, ...)
 #endif
 
 
@@ -226,6 +264,10 @@ do { \
 
 #ifndef compile_assert0
 #error compile_assert0 not defined
+#endif
+
+#ifndef compile_assert_const_p
+#error compile_assert_const_p not defined
 #endif
 
 #endif // COMPILE_ASSERT_H

--- a/compile_assert.h
+++ b/compile_assert.h
@@ -169,7 +169,7 @@ void * _stop_compile2() __attribute__ ((error("'compile_assert pointer error det
 #define compile_assert_ptr(condition, ptr) ((condition) ? (ptr) : _stop_compile2())
 
 #else
-#define compile_assert_ptr(condition, ptr)
+#define compile_assert_ptr(condition, ptr) ptr
 #endif
 
 

--- a/compile_assert.h
+++ b/compile_assert.h
@@ -215,6 +215,9 @@ int _stop_compile3() __attribute__ ((error("'compile_assert_scalar error detecte
 #define MERGE1(a,b) MERGE2(a,b)
 #define MERGE3(a,b,c) MERGE1(a, MERGE1(b,c))
 
+// The non-active fallback above already defined these as empty
+#undef compile_assert
+#undef compile_assert0
 #define compile_assert(expr, message) \
 do { \
     if (!(expr)) { \
@@ -232,13 +235,6 @@ do { \
 
 #endif // defined(__ENABLE_COMPILE_ASSERT__)
 #endif // defined(_MSC_VER)
-
-// Compile out the other variants for the moment
-#if defined(_MSC_VER)
-#define compile_assert_ptr(condition, ptr) ptr
-#define compile_assert_never_null(ptr) ptr
-#define compile_assert_scalar(condition, scalar) scalar
-#endif
 
 // Generic compiler support, via a missing symbol
 #if defined(__ENABLE_COMPILE_ASSERT__)

--- a/compile_assert.h
+++ b/compile_assert.h
@@ -42,6 +42,11 @@
  * output.
  */
 
+// compile_assert() takes an optional message: compile_assert(expr) or compile_assert(expr, "why").
+#define CA_FIRST(first, ...) first
+#define CA_MSG(...) CA_MSG_(__VA_ARGS__, "")
+#define CA_MSG_(expression, message, ...) message
+
 #ifdef __GNUC__
 
 // This library relies on the GCC/Clang function 'error' attribute.
@@ -73,7 +78,7 @@
  * @def compile_assert
  * @brief Macro for compile-time assertions.
  * @param expression The compile-time condition to be checked.
- * @param message A description of the assertion.
+ * @param message Optional description of the assertion; defaults to "" when omitted.
  */
 #define CA_ASSERT_IMPL(expression, message, fn) \
     do { \
@@ -82,8 +87,8 @@
             fn(); \
         } \
     } while (0)
-#define compile_assert(expression, message) \
-    CA_ASSERT_IMPL(expression, message, CA_CAT(_compile_assert_fail_, __COUNTER__))
+#define compile_assert(...) \
+    CA_ASSERT_IMPL(CA_FIRST(__VA_ARGS__), CA_MSG(__VA_ARGS__), CA_CAT(_compile_assert_fail_, __COUNTER__))
 
 
 // compile_assert_const_p turns a provably-constant precondition violation into a build error.
@@ -132,12 +137,8 @@
         CA_CONST_P_GUARD(condition, __VA_ARGS__), \
         CA_CAT(_compile_assert_fail_, __COUNTER__))
 
-
-#define compile_assert0(expression) compile_assert(expression, NULL)
-
 #else
-#define compile_assert(condition, description)
-#define compile_assert0(expression)
+#define compile_assert(...)
 #define compile_assert_const_p(condition, message, ...)
 #endif
 
@@ -215,22 +216,18 @@ int _stop_compile3() __attribute__ ((error("'compile_assert_scalar error detecte
 #define MERGE1(a,b) MERGE2(a,b)
 #define MERGE3(a,b,c) MERGE1(a, MERGE1(b,c))
 
-// The non-active fallback above already defined these as empty
+// The non-active fallback above already defined this as empty
 #undef compile_assert
-#undef compile_assert0
-#define compile_assert(expr, message) \
+#define compile_assert(...) \
 do { \
-    if (!(expr)) { \
+    if (!(CA_FIRST(__VA_ARGS__))) { \
       extern void MERGE3(_compile_assert, COMPILE_FILE, __LINE__)(); \
       MERGE3(_compile_assert, COMPILE_FILE, __LINE__)(); \
     } \
 } while (0)
-
-#define compile_assert0(expression) compile_assert(expression, NULL)
 #else
 
-#define compile_assert(condition, description)
-#define compile_assert0(expression)
+#define compile_assert(...)
 #define COMPILE_ASSERT_ACTIVE
 
 #endif // defined(__ENABLE_COMPILE_ASSERT__)
@@ -241,25 +238,19 @@ do { \
 #if !defined(compile_assert)
 #define COMPILE_ASSERT_ACTIVE
 
-#define compile_assert(expression, message) \
+#define compile_assert(...) \
     do { \
         void _compile_assert_fail(); \
-        if (!(expression)) { \
+        if (!(CA_FIRST(__VA_ARGS__))) { \
             _compile_assert_fail(); \
         } \
     } while (0)
-
-#define compile_assert0(expression) compile_assert(expression, NULL)
 #endif // !defined(compile_assert)
 #endif // defined(__ENABLE_COMPILE_ASSERT__)
 
 
 #ifndef compile_assert
 #error compile_assert not defined
-#endif
-
-#ifndef compile_assert0
-#error compile_assert0 not defined
 #endif
 
 #ifndef compile_assert_const_p

--- a/compile_assert.h
+++ b/compile_assert.h
@@ -64,27 +64,32 @@
  * @see compile_assert
  */
 
+// The failure function carries the error message via the error attribute.
+// Its name is made unique per expansion with __COUNTER__
+#define CA_CAT2(a, b) a##b
+#define CA_CAT(a, b) CA_CAT2(a, b)
+
 /**
  * @def compile_assert
  * @brief Macro for compile-time assertions.
  * @param expression The compile-time condition to be checked.
  * @param message A description of the assertion.
  */
-#define compile_assert(expression, message) \
+#define CA_ASSERT_IMPL(expression, message, fn) \
     do { \
-        void _compile_assert_fail() __attribute__ ((error(message))); \
+        void fn() __attribute__ ((error(message))); \
         if (!(expression)) { \
-            _compile_assert_fail(); \
+            fn(); \
         } \
     } while (0)
+#define compile_assert(expression, message) \
+    CA_ASSERT_IMPL(expression, message, CA_CAT(_compile_assert_fail_, __COUNTER__))
 
 
-#define compile_assert_const_p(expression, message) \
-    do { \
-        if(__builtin_constant_p(expression)) { \
-            if (!(expression)) { \
-                void _compile_assert_fail() __attribute__ ((error(message))); \
-                _compile_assert_fail(); \
+// compile_assert_const_p turns a provably-constant precondition violation into a build error.
+// The optional trailing arguments name the operands that must be compile-time constants for the
+// check to fire; with none given, the condition itself is the guarded operand:
+//
             } \
         } \
     } while (0)

--- a/compile_assert.h
+++ b/compile_assert.h
@@ -43,6 +43,13 @@
  */
 
 #ifdef __GNUC__
+
+// This library relies on the GCC/Clang function 'error' attribute.
+// GCC has always supported it, but Clang only supports it from version 14.
+#if defined(__ENABLE_COMPILE_ASSERT__) && !(defined(__has_attribute) && __has_attribute(error))
+#error "__ENABLE_COMPILE_ASSERT__ requires the 'error' function attribute, available on GCC and on Clang 14 or later."
+#endif
+
 #if defined(__OPTIMIZE__) && defined(__ENABLE_COMPILE_ASSERT__)
 #define GCC_COMPILE_ASSERT
 #define COMPILE_ASSERT_ACTIVE

--- a/main13/makefile
+++ b/main13/makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -O3 -std=c11
+CFLAGS = -Wall -Wextra -O3 -std=c11 -D__ENABLE_COMPILE_ASSERT__
 
 TARGET = main13.bin
 SRC_DIR = .
@@ -8,12 +8,7 @@ OBJ_DIR = .
 SRC_FILES = $(wildcard $(SRC_DIR)/*.c)
 OBJ_FILES = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRC_FILES))
 
-.PHONY clean
-
-
-clean:
-	rm -f *.o
-	rm -f $(TARGET)
+.PHONY: all clean
 
 all: $(TARGET)
 

--- a/proposal/proposal.txt
+++ b/proposal/proposal.txt
@@ -138,7 +138,7 @@ It defines COMPILE_ASSERT_ACTIVE which an application can check.
 
 A user who receives a file within which they wish to disable compile_assert could also
 #undef compile_assert
-#define compile_assert(expression, message)
+#define compile_assert(...)
 
 GCC and Clang both support __attribute__ ((error(message))), GCC since gcc-4.5.3 in 2011. The attribute is not standardized. They do both support [[gnu:error(message)]] which can also be used.
 
@@ -191,22 +191,24 @@ While there is no compiler supporting this feature directly, I created the follo
  * @def compile_assert
  * @brief Macro for compile-time assertion in optimized builds.
  * @param expression The compile-time condition to be checked.
- * @param message A description of the assertion (unused).
+ * @param message Optional description of the assertion (unused); defaults to "".
  */
-#define compile_assert(expression, message) \
+// compile_assert(expr) or compile_assert(expr, "message"); the message is optional.
+// CA_FIRST yields the expression, CA_MSG the message (defaulting to "").
+#define CA_FIRST(first, ...) first
+#define CA_MSG(...) CA_MSG_(__VA_ARGS__, "")
+#define CA_MSG_(expression, message, ...) message
+
+#define compile_assert(...) \
     do { \
-        void _compile_assert_fail() __attribute__ ((error(message))); \
-        if (!(expression)) { \
+        void _compile_assert_fail() __attribute__ ((error(CA_MSG(__VA_ARGS__)))); \
+        if (!(CA_FIRST(__VA_ARGS__))) { \
             _compile_assert_fail(); \
         } \
     } while (0)
 
-// NB, would rather pass NULL to this.
-#define compile_assert0(expression) compile_assert(expression, "")
-
 #else
-#define compile_assert(condition, description)
-#define compile_assert0(expression)
+#define compile_assert(...)
 #endif
 
 Compilers that do not support GCC’s error attribute could stop the compilation of the translation unit another way, eg inline assembler of an instruction that does not exist, eg asm(“stop_build”); this also works on GCC.
@@ -219,9 +221,9 @@ C:\dev\> cl /DCOMPILE_FILE=__FILE_msvc18_cpp_
 #define MERGE1(a,b) MERGE2(a,b)
 #define MERGE3(a,b,c) MERGE1(a, MERGE1(b,c))
 
-#define compile_assert(expr, message) \
+#define compile_assert(...) \
 do { \
-    if (!(expr)) { \
+    if (!(CA_FIRST(__VA_ARGS__))) { \
       extern void MERGE3(_compile_assert, COMPILE_FILE, __LINE__)(); \
       MERGE3(_compile_assert, COMPILE_FILE, __LINE__)(); \
     } \
@@ -352,17 +354,28 @@ proposal.c:9:5: note: in expansion of macro ‘compile_assert’
       |     ^~~~~~~~~~~~~~
 
 $ make
-gcc -Wall -Wextra -O3 -std=c11 -c -o main13.o main13.c
+gcc -Wall -Wextra -O3 -std=c11 -D__ENABLE_COMPILE_ASSERT__ -c -o main13.o main13.c
 In file included from main13.c:8:
 main13.c: In function ‘main’:
-<snip>
-main13_api.h:14:5: note: in expansion of macro ‘compile_assert’
-   14 |     compile_assert((str != NULL), "cannot be NULL"); \
-      |     ^~~~~~~~~~~~~~
-main13.c:16:5: note: in expansion of macro ‘log_api’
-   16 |     log_api(str);
-      |     ^~~~~~~
-make: *** [makefile:17: main13.o] Error 1
+./../compile_assert.h:154:57: error: call to ‘_stop_compile2’ declared with attribute error: 'compile_assert pointer error detected'
+  154 | #define compile_assert_never_null(ptr) ((ptr) ? (ptr) : _stop_compile2())
+      |                                                         ^~~~~~~~~~~~~~~~
+main13_api.h:11:48: note: in expansion of macro ‘compile_assert_never_null’
+   11 | #define log_api(str, length) _internal_log_api(compile_assert_never_null(str), compile_assert_scalar((length != 0), length))
+      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~
+main13.c:18:18: note: in expansion of macro ‘log_api’
+   18 |     int result = log_api(str, 0);
+      |                  ^~~~~~~
+./../compile_assert.h:186:74: error: call to ‘_stop_compile3’ declared with attribute error: 'compile_assert_scalar error detected'
+  186 | #define compile_assert_scalar(condition, scalar) ((condition) ? (scalar) : _stop_compile3())
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
+main13_api.h:11:80: note: in expansion of macro ‘compile_assert_scalar’
+   11 | #define log_api(str, length) _internal_log_api(compile_assert_never_null(str), compile_assert_scalar((length != 0), length))
+      |                                                                                ^~~~~~~~~~~~~~~~~~~~~
+main13.c:18:18: note: in expansion of macro ‘log_api’
+   18 |     int result = log_api(str, 0);
+      |                  ^~~~~~~
+make: *** [makefile:19: main13.o] Error 1
 
 
 
@@ -503,6 +516,10 @@ Secure Software Development Framework SSDF https://csrc.nist.gov/Projects/ssdf
 
 20. ChangeLog
 
+Since previous R1 (2026-02-28)
+
+a) compile_assert is now a single variadic macro: compile_assert(expression) and compile_assert(expression, message) are both accepted, the message is optional. The separate compile_assert0 has been removed.
+
 Since previous R0 (2026-02-22)
 
 a) MSVC is now a supported compiler.
@@ -516,3 +533,4 @@ e) Tests added that verify constraints before and after fixes at compile time. h
 
 2026-02-22: R0
 2026-02-28: R1
+2026-07-14: R2 (draft)

--- a/proposal/proposal_c.txt
+++ b/proposal/proposal_c.txt
@@ -196,7 +196,7 @@ It defines COMPILE_ASSERT_ACTIVE which an application can check.
 
 A user who receives a file within which they wish to disable compile_assert could also
 #undef compile_assert
-#define compile_assert(expression, message)
+#define compile_assert(...)
 
 GCC and Clang both support __attribute__ ((error(message))), GCC since version 4.5.3 (2011). The attribute is not standardized, they do both support [[gnu:error(message)]] which can also be used.
 
@@ -249,22 +249,24 @@ While there is no compiler supporting this feature directly, I created the follo
  * @def compile_assert
  * @brief Macro for compile-time assertion in certain builds.
  * @param expression The compile-time condition to be checked.
- * @param message A description of the assertion (unused).
+ * @param message Optional description of the assertion (unused); defaults to "".
  */
-#define compile_assert(expression, message) \
+// compile_assert(expr) or compile_assert(expr, "message"); the message is optional.
+// CA_FIRST yields the expression, CA_MSG the message (defaulting to "").
+#define CA_FIRST(first, ...) first
+#define CA_MSG(...) CA_MSG_(__VA_ARGS__, "")
+#define CA_MSG_(expression, message, ...) message
+
+#define compile_assert(...) \
     do { \
-        void _compile_assert_fail() __attribute__ ((error(message))); \
-        if (!(expression)) { \
+        void _compile_assert_fail() __attribute__ ((error(CA_MSG(__VA_ARGS__)))); \
+        if (!(CA_FIRST(__VA_ARGS__))) { \
             _compile_assert_fail(); \
         } \
     } while (0)
 
-// NB, would rather pass NULL to this.
-#define compile_assert0(expression) compile_assert(expression, "")
-
 #else
-#define compile_assert(condition, description)
-#define compile_assert0(expression)
+#define compile_assert(...)
 #endif
 
 Compilers that do not support GCC’s error attribute could stop the compilation of the translation unit another way, eg inline assembler of an instruction that does not exist, ie. asm(“stop_build”); this also works on GCC.
@@ -277,9 +279,9 @@ C:\dev\> cl /DCOMPILE_FILE=__FILE_msvc18_c_
 #define MERGE1(a,b) MERGE2(a,b)
 #define MERGE3(a,b,c) MERGE1(a, MERGE1(b,c))
 
-#define compile_assert(expr, message) \
+#define compile_assert(...) \
 do { \
-    if (!(expr)) { \
+    if (!(CA_FIRST(__VA_ARGS__))) { \
       extern void MERGE3(_compile_assert, COMPILE_FILE, __LINE__)(); \
       MERGE3(_compile_assert, COMPILE_FILE, __LINE__)(); \
     } \
@@ -417,17 +419,28 @@ proposal.c:9:5: note: in expansion of macro ‘compile_assert’
       |     ^~~~~~~~~~~~~~
 
 $ make
-gcc -Wall -Wextra -O3 -std=c11 -c -o main13.o main13.c
+gcc -Wall -Wextra -O3 -std=c11 -D__ENABLE_COMPILE_ASSERT__ -c -o main13.o main13.c
 In file included from main13.c:8:
 main13.c: In function ‘main’:
-<snip>
-main13_api.h:14:5: note: in expansion of macro ‘compile_assert’
-   14 |     compile_assert((str != NULL), "cannot be NULL"); \
-      |     ^~~~~~~~~~~~~~
-main13.c:16:5: note: in expansion of macro ‘log_api’
-   16 |     log_api(str);
-      |     ^~~~~~~
-make: *** [makefile:17: main13.o] Error 1
+./../compile_assert.h:154:57: error: call to ‘_stop_compile2’ declared with attribute error: 'compile_assert pointer error detected'
+  154 | #define compile_assert_never_null(ptr) ((ptr) ? (ptr) : _stop_compile2())
+      |                                                         ^~~~~~~~~~~~~~~~
+main13_api.h:11:48: note: in expansion of macro ‘compile_assert_never_null’
+   11 | #define log_api(str, length) _internal_log_api(compile_assert_never_null(str), compile_assert_scalar((length != 0), length))
+      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~
+main13.c:18:18: note: in expansion of macro ‘log_api’
+   18 |     int result = log_api(str, 0);
+      |                  ^~~~~~~
+./../compile_assert.h:186:74: error: call to ‘_stop_compile3’ declared with attribute error: 'compile_assert_scalar error detected'
+  186 | #define compile_assert_scalar(condition, scalar) ((condition) ? (scalar) : _stop_compile3())
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
+main13_api.h:11:80: note: in expansion of macro ‘compile_assert_scalar’
+   11 | #define log_api(str, length) _internal_log_api(compile_assert_never_null(str), compile_assert_scalar((length != 0), length))
+      |                                                                                ^~~~~~~~~~~~~~~~~~~~~
+main13.c:18:18: note: in expansion of macro ‘log_api’
+   18 |     int result = log_api(str, 0);
+      |                  ^~~~~~~
+make: *** [makefile:19: main13.o] Error 1
 
 
 

--- a/testsuite/main1_a.c
+++ b/testsuite/main1_a.c
@@ -11,7 +11,7 @@ static void my_test(const char * p)
 {
     compile_assert(p, "main1_a check not null in: " __FILE__ ":" TOSTRING(__LINE__));
 
-    compile_assert0(p[0] == 'H');
+    compile_assert(p[0] == 'H');
 
     printf("%s\n", p);
 }

--- a/testsuite/main1_b.c
+++ b/testsuite/main1_b.c
@@ -11,7 +11,7 @@ static void my_test(const char * p)
 {
     compile_assert(p, "main1_a check not null in: " __FILE__ ":" TOSTRING(__LINE__));
 
-    compile_assert(p[0] == 'H', "");
+    compile_assert(p[0] == 'H');
 
     printf("%s\n", p);
 }

--- a/testsuite/makefile
+++ b/testsuite/makefile
@@ -24,7 +24,7 @@ LOG := > /dev/null 2>&1
 #LOG := >> testsuite.log 2>&1
 
 
-all: start main1_a main1_b main2_a main2_b main3_a main3_b main4_a main4_b main5_a main5_b main6_a main6_b main17_a main17_b test_20_a main24_a main24_b main25_a main25_b main28_a main28_b main29_a main29_b test_30_web_a test_30_web_b
+all: start main1_a main1_b main2_a main2_b main3_a main3_b main4_a main4_b main5_a main5_b main6_a main6_b main17_a main17_b test_20_a main24_a main24_b main25_a main25_b main28_a main28_b main29_a main29_b test_30_web_a test_30_web_b test_31_const_p_a test_31_const_p_b test_32_div_zero_a test_32_div_zero_b
 
 start:
 	echo "compile_assert() testsuite"
@@ -305,6 +305,46 @@ test_30_web_b:
 		echo "test_30_web_b: PASS"; \
 	else \
 		echo "test_30_web_b: *FAIL*"; \
+	fi
+
+
+# should *not* compile
+test_31_const_p_a:
+	$(CC) $(INC_DIRS) $(FLAGS) -o test_31_const_p_a.bin test_31_const_p_a.c $(LOG); \
+	if [ $$? -eq 0 ]; then \
+		echo "test_31_const_p_a: *FAIL*"; \
+	else \
+		echo "test_31_const_p_a: PASS"; \
+	fi
+
+
+# should compile
+test_31_const_p_b:
+	$(CC) $(INC_DIRS) $(FLAGS) -o test_31_const_p_b.bin test_31_const_p_b.c $(LOG); \
+	if [ $$? -eq 0 ]; then \
+		echo "test_31_const_p_b: PASS"; \
+	else \
+		echo "test_31_const_p_b: *FAIL*"; \
+	fi
+
+
+# should *not* compile
+test_32_div_zero_a:
+	$(CC) $(INC_DIRS) $(FLAGS) -Wno-div-by-zero -o test_32_div_zero_a.bin test_32_div_zero_a.c $(LOG); \
+	if [ $$? -eq 0 ]; then \
+		echo "test_32_div_zero_a: *FAIL*"; \
+	else \
+		echo "test_32_div_zero_a: PASS"; \
+	fi
+
+
+# should compile
+test_32_div_zero_b:
+	$(CC) $(INC_DIRS) $(FLAGS) -Wno-div-by-zero -o test_32_div_zero_b.bin test_32_div_zero_b.c $(LOG); \
+	if [ $$? -eq 0 ]; then \
+		echo "test_32_div_zero_b: PASS"; \
+	else \
+		echo "test_32_div_zero_b: *FAIL*"; \
 	fi
 
 

--- a/testsuite/makefile
+++ b/testsuite/makefile
@@ -55,9 +55,9 @@ main1_b:
 main2_a:
 	$(CC) $(INC_DIRS) $(FLAGS) -Wno-nonnull -o main2_a.bin main2_a.c $(LOG); \
 	if [ $$? -eq 0 ]; then \
-		echo "main1_a: *FAIL*"; \
+		echo "main2_a: *FAIL*"; \
 	else \
-		echo "main1_a: PASS"; \
+		echo "main2_a: PASS"; \
 	fi
 
 # should compile
@@ -174,9 +174,9 @@ main17_b:
 main24_a:
 	$(CXX) $(INC_DIRS) $(FLAGS) -o main24_a.bin main24_a.cpp $(LOG); \
 	if [ $$? -eq 0 ]; then \
-		echo "main25_a: *FAIL*"; \
+		echo "main24_a: *FAIL*"; \
 	else \
-		echo "main25_a: PASS"; \
+		echo "main24_a: PASS"; \
 	fi
 
 # should compile

--- a/testsuite/test_31_const_p_a.c
+++ b/testsuite/test_31_const_p_a.c
@@ -1,0 +1,21 @@
+// gcc -I.. -D__ENABLE_COMPILE_ASSERT__ -O2 -o test_31_const_p_a.bin test_31_const_p_a.c
+
+// Demonstrates the variadic compile_assert_const_p(). The trailing arguments name the
+// compile-time-constant operands that gate the check: the assert only fires when every
+// listed operand is __builtin_constant_p. Here the message (12 bytes) does not fit the
+// buffer (8 bytes) and both operands are constants, so the check fires.
+//
+// This is the un-fixed version, so it must *not* compile.
+
+#include "compile_assert.h"
+
+#define BUF_SIZE 8
+#define MSG_LEN  12
+
+int main(void)
+{
+    compile_assert_const_p(MSG_LEN <= BUF_SIZE,
+                           "message does not fit in buffer",
+                           MSG_LEN, BUF_SIZE);
+    return 0;
+}

--- a/testsuite/test_31_const_p_b.c
+++ b/testsuite/test_31_const_p_b.c
@@ -1,0 +1,17 @@
+// gcc -I.. -D__ENABLE_COMPILE_ASSERT__ -O2 -o test_31_const_p_b.bin test_31_const_p_b.c
+
+// The fix: the message now fits within the buffer, so the variadic
+// compile_assert_const_p() check is satisfied and the program compiles cleanly.
+
+#include "compile_assert.h"
+
+#define BUF_SIZE 8
+#define MSG_LEN  6
+
+int main(void)
+{
+    compile_assert_const_p(MSG_LEN <= BUF_SIZE,
+                           "message does not fit in buffer",
+                           MSG_LEN, BUF_SIZE);
+    return 0;
+}

--- a/testsuite/test_32_div_zero_a.c
+++ b/testsuite/test_32_div_zero_a.c
@@ -1,0 +1,27 @@
+// gcc -I.. -D__ENABLE_COMPILE_ASSERT__ -O2 -Wno-div-by-zero -o test_32_div_zero_a.bin test_32_div_zero_a.c
+
+// Demonstrates catching a division by a compile-time-constant zero *at build time* with
+// compile_assert_const_p(), before it becomes runtime undefined behaviour. Naming DIVISOR as
+// the guarded operand makes the check fire when the divisor is a known-constant zero.
+//
+// Note: a constant "/0" is only a warning to the compiler (silenced here with
+// -Wno-div-by-zero), so absent the guard this would still build and then crash at runtime.
+// It is compile_assert_const_p that turns it into a hard build error.
+//
+// This is the un-fixed version (DIVISOR == 0), so it must *not* compile.
+
+#include "compile_assert.h"
+
+#define NUMERATOR 100
+#define DIVISOR   0
+
+static int checked_divide(void)
+{
+    compile_assert_const_p(DIVISOR != 0, "division by zero", DIVISOR);
+    return NUMERATOR / DIVISOR;
+}
+
+int main(void)
+{
+    return checked_divide();
+}

--- a/testsuite/test_32_div_zero_b.c
+++ b/testsuite/test_32_div_zero_b.c
@@ -1,0 +1,20 @@
+// gcc -I.. -D__ENABLE_COMPILE_ASSERT__ -O2 -Wno-div-by-zero -o test_32_div_zero_b.bin test_32_div_zero_b.c
+
+// The fix: DIVISOR is now non-zero, so the compile_assert_const_p() guard is satisfied and the
+// division is safe. The program compiles cleanly.
+
+#include "compile_assert.h"
+
+#define NUMERATOR 100
+#define DIVISOR   5
+
+static int checked_divide(void)
+{
+    compile_assert_const_p(DIVISOR != 0, "division by zero", DIVISOR);
+    return NUMERATOR / DIVISOR;
+}
+
+int main(void)
+{
+    return checked_divide();
+}


### PR DESCRIPTION
This is an omnibus PR with the changes I've applied in my own repo as well as various other fixes to get things running smoothly here:

1) Make `compile_assert` variadic so that there's no need for `compile_assert0` anymore
2) Make `compile_assert_const_p` variadic with up to 8 arguments. Being able to specify an operand should be constant helps significantly with deep call chains and older GCC versions.
3) Add some additional test for `compile_assert_const_p` that shows the addition of the operands
4) Fix multiple definitions of macros for MSVC platforms
5) Fix main13 makefile and update the output of it in the proposals and README

Please let me know if you have any questions or concerns